### PR TITLE
Allowing AbstractStep subclasses to get the launch mode from ProjectInspector instances.

### DIFF
--- a/repairnator/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
+++ b/repairnator/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
@@ -209,6 +209,10 @@ public class ProjectInspector {
     public NopolRepair getNopolRepair() {
         return nopolRepair;
     }
+    
+    public RepairMode getMode() {
+    	return mode;
+    }
 
     public String toString() {
         return this.getRepoLocalPath()+" : "+this.getState();

--- a/repairnator/src/main/java/fr/inria/spirals/repairnator/process/step/GatherTestInformation.java
+++ b/repairnator/src/main/java/fr/inria/spirals/repairnator/process/step/GatherTestInformation.java
@@ -153,24 +153,14 @@ public class GatherTestInformation extends AbstractStep {
         }
 
         if (this.getState() == ProjectState.HASTESTFAILURE) {
-        	if (!(inspector.getMode() == RepairMode.FORBEARS)) {
-        		this.shouldStop = false;
-        	} else {
-        		this.shouldStop = true;
-        	}
+        	this.shouldStop = false;
         } else if (this.getState() == ProjectState.HASTESTERRORS) {
             this.addStepError("Only get test errors, no failing tests. It will try to repair it.");
-            if (!(inspector.getMode() == RepairMode.FORBEARS)) {
-        		this.shouldStop = false;
-        	} else {
-        		this.shouldStop = true;
-        	}
+            this.shouldStop = false;
         } else {
-        	if (!(inspector.getMode() == RepairMode.FORBEARS)) {
-        		this.shouldStop = true;
-        	} else {
-        		this.shouldStop = false;
-        	}
+        	this.shouldStop = true;
         }
+        
+        this.shouldStop = (inspector.getMode() == RepairMode.FORBEARS) ? !this.shouldStop : this.shouldStop;
     }
 }

--- a/repairnator/src/main/java/fr/inria/spirals/repairnator/process/step/GatherTestInformation.java
+++ b/repairnator/src/main/java/fr/inria/spirals/repairnator/process/step/GatherTestInformation.java
@@ -1,6 +1,8 @@
 package fr.inria.spirals.repairnator.process.step;
 
 import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.Launcher;
+import fr.inria.spirals.repairnator.RepairMode;
 import fr.inria.spirals.repairnator.process.ProjectState;
 import fr.inria.spirals.repairnator.process.testinformation.FailureLocation;
 import fr.inria.spirals.repairnator.process.testinformation.FailureType;
@@ -151,12 +153,24 @@ public class GatherTestInformation extends AbstractStep {
         }
 
         if (this.getState() == ProjectState.HASTESTFAILURE) {
-            this.shouldStop = false;
+        	if (!(inspector.getMode() == RepairMode.FORBEARS)) {
+        		this.shouldStop = false;
+        	} else {
+        		this.shouldStop = true;
+        	}
         } else if (this.getState() == ProjectState.HASTESTERRORS) {
             this.addStepError("Only get test errors, no failing tests. It will try to repair it.");
-            this.shouldStop = false;
+            if (!(inspector.getMode() == RepairMode.FORBEARS)) {
+        		this.shouldStop = false;
+        	} else {
+        		this.shouldStop = true;
+        	}
         } else {
-            this.shouldStop = true;
+        	if (!(inspector.getMode() == RepairMode.FORBEARS)) {
+        		this.shouldStop = true;
+        	} else {
+        		this.shouldStop = false;
+        	}
         }
     }
 }

--- a/repairnator/src/main/java/fr/inria/spirals/repairnator/process/step/NopolRepair.java
+++ b/repairnator/src/main/java/fr/inria/spirals/repairnator/process/step/NopolRepair.java
@@ -73,7 +73,7 @@ public class NopolRepair extends AbstractStep {
 
             this.getLogger().debug("Launching repair with Nopol for following test class: "+testClass+" (should timeout in "+timeout+" minutes");
 
-            ProjectReference projectReference = new ProjectReference(sources, classPath.toArray(new URL[classPath.size()]), new String[] {testClass});
+            final ProjectReference projectReference = new ProjectReference(sources, classPath.toArray(new URL[classPath.size()]), new String[] {testClass});
             Config config = new Config();
             config.setComplianceLevel(8);
             config.setTimeoutTestExecution(60);


### PR DESCRIPTION
Since some existing Repairnator steps will be useful for Bears, and some parts of them should have to behaviour differently for Bears, it's important to allow that the steps can check if they are running for Repairnator or Bears.