### PR TITLE
Fixing a java.lang.NumberFormatException when running travisFilter.

### DIFF
--- a/jtravis/src/main/java/fr/inria/spirals/jtravis/helpers/BuildHelper.java
+++ b/jtravis/src/main/java/fr/inria/spirals/jtravis/helpers/BuildHelper.java
@@ -235,7 +235,10 @@ public class BuildHelper extends AbstractHelper {
 
         int after_number = 0;
         try {
-            after_number = Integer.parseInt(build.getNumber());
+            String numberStr = build.getNumber();
+            if (numberStr != null) {
+                after_number = Integer.parseInt(numberStr);
+            }
         } catch (NumberFormatException e) {
             getInstance().getLogger().error("Error while parsing build number for build id: "+build.getId(),e);
             return null;


### PR DESCRIPTION
Example of the exception:

13:13:29.930 [main] ERROR f.i.s.jtravis.helpers.BuildHelper - Error while parsing build number for build id: 150664938
java.lang.NumberFormatException: null
	at java.lang.Integer.parseInt(Integer.java:542)
	at java.lang.Integer.parseInt(Integer.java:615)
	at fr.inria.spirals.jtravis.helpers.BuildHelper.getLastBuildOfSameBranchOfStatusBeforeBuild(BuildHelper.java:238)
	at fr.inria.spirals.librepair.travisfilter.Launcher.getListOfValidRepository(Launcher.java:59)
	at fr.inria.spirals.librepair.travisfilter.Launcher.main(Launcher.java:153)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)