### PR TITLE
Add an explicit exit in the pipeline to avoid main thread to be blocked

### DIFF
--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
@@ -227,6 +227,9 @@ public class Launcher {
             inspector = new ProjectInspector(buildToBeInspected, this.config.getWorkspacePath(), serializers);
         }
         inspector.run();
+
+        LOGGER.info("Inspector is finished. The process will now exit.");
+        System.exit(0);
     }
 
     public static void main(String[] args) throws IOException, JSAPException {


### PR DESCRIPTION
Sometimes the main process is not exited even if the whole pipeline is finished, leading to errors like #131 . The problem should certainly come from non-daemon threads which are still running, blocking the main process. A first PR has been proposed in Nopol to master this issue (see https://github.com/SpoonLabs/nopol/pull/136), but it may not be enough. So I propose to explicitely exit the main process at the end of the pipeline. 